### PR TITLE
feat: add delete message rest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ fn main() {
 
 fn on_ping(mut client vd.Client, evt &vd.MessageCreate) {
     if evt.content == '!ping' {
-        client.send(evt.channel_id, 'pong!') or { }
+        client.channel_message_send(evt.channel_id, 'pong!') or { }
     }
 }
 ```

--- a/examples/ping-pong/main.v
+++ b/examples/ping-pong/main.v
@@ -23,6 +23,6 @@ fn on_ping(mut client vd.Client, evt &vd.MessageCreate) {
 	// If content of message is '!ping' reply with 'pong!'
 	if evt.content == '!ping' {
 		// Send message to channel
-		client.send(evt.channel_id, 'pong!') or { }
+		client.channel_message_send(evt.channel_id, 'pong!') or { }
 	}
 }

--- a/examples/upload-image/main.v
+++ b/examples/upload-image/main.v
@@ -25,7 +25,7 @@ fn img(mut client vd.Client, evt &vd.MessageCreate) {
 	// If content of message is '!image' reply with image
 	if evt.content == '!image' {
 		// Send image to channel
-		client.send(evt.channel_id, vd.File{
+		client.channel_message_send(evt.channel_id, vd.File{
 			filename: 'v-logo.png'
 			// You can embed image as i did, but you can do it at runtime `os.read_file()` etc.
 			data: binary.v_logo_png[0..binary.v_logo_png_len]

--- a/rest.v
+++ b/rest.v
@@ -43,3 +43,15 @@ pub fn (mut client Client) send(channel_id string, message Payload) ? {
 		return error(err_text)
 	}
 }
+
+// Delete message from a channel
+pub fn (mut client Client) delete_message(channel_id string, message_id string) ? {
+	mut req := rest.new_request(client.token, .delete, '/channels/$channel_id/messages/$message_id') ?
+
+	resp := client.rest.do(req) ?
+	if resp.status_code != 204 {
+		response_error := rest.ResponseCode(resp.status_code)
+		err_text := 'Status code is $resp.status_code ($response_error).\n'
+		return error(err_text)
+	}
+}

--- a/rest.v
+++ b/rest.v
@@ -7,7 +7,7 @@ import discordv.util
 type Payload = File | Message | string | Embed
 
 // Send message to channel
-pub fn (mut client Client) send(channel_id string, message Payload) ? {
+pub fn (mut client Client) channel_message_send(channel_id string, message Payload) ? {
 	mut req := rest.new_request(client.token, .post, '/channels/$channel_id/messages') ?
 	match message {
 		string {
@@ -45,7 +45,7 @@ pub fn (mut client Client) send(channel_id string, message Payload) ? {
 }
 
 // Delete message from a channel
-pub fn (mut client Client) delete_message(channel_id string, message_id string) ? {
+pub fn (mut client Client) channel_message_delete(channel_id string, message_id string) ? {
 	mut req := rest.new_request(client.token, .delete, '/channels/$channel_id/messages/$message_id') ?
 
 	resp := client.rest.do(req) ?


### PR DESCRIPTION
Maybe `client.send()` should be renamed to `client.send_message()`? I don't know, maybe `client.delete()` is better than `client.delete_message()` so we can keep `client.send()` but if we use `client.delete_message()` I think that `client.send_message()` is more consistent?