### PR TITLE
fix: specify int in identify payload

### DIFF
--- a/gateway/packets/identify.v
+++ b/gateway/packets/identify.v
@@ -27,8 +27,8 @@ pub fn (d Identify) to_json_any() json.Any {
 	obj['intents'] = int(d.intents)
 	if d.shard.len != 2 {
 		mut shards := []json.Any{}
-		shards << 0
-		shards << 1
+		shards << int(0)
+		shards << int(1)
 		obj['shard'] = shards
 	} else {
 		mut shards := []json.Any{}


### PR DESCRIPTION
I needed to cast 0 and 1 to int type to run the bot on Linux, but this could be changed by the V team, see https://discord.com/channels/592103645835821068/592294828432424960/794855115902287883 (on their discord server).
