### PR TITLE
Fix improper capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More [examples](https://github.com/Terisback/discord.v/blob/master/examples/)
 ### Install via vpm
 
 ```bash
-v install terisback.discordv
+v install Terisback.discordv
 ```
 
 ### Install via git


### PR DESCRIPTION
`v install terisback.discordv` returns an error saying it doesn't exist, but `v install Terisback.discordv` does work, so it appears to be case-sensitive.