### PR TITLE
fix ACIDO memory issues

### DIFF
--- a/structs.v
+++ b/structs.v
@@ -1985,8 +1985,8 @@ pub fn (mut acid ApplicationCommandInteractionData) from_json(f map[string]json.
 			}
 			'options' {
 				mut arr := from_json_arr<ApplicationCommandInteractionDataOption>(v.arr())
-				for item in arr {
-					acid.options << &item
+				for mut item in arr {
+					acid.options << item
 				}
 			}
 			else {}


### PR DESCRIPTION
before printing this would cause a runtime crash and there were duplicate values. works as intended now