### PR TITLE
`__v_thread_wait` redefinition because of parallel compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import terisback.discordv as vd
 fn main() {
     mut client := vd.new(token: 'token') ?
     client.on_message_create(on_ping)
-    client.run().wait()
+    client.run()
 }
 
 fn on_ping(mut client vd.Client, evt &vd.MessageCreate) {


### PR DESCRIPTION
it duplicates a function if you have .wait() in the end of the run function